### PR TITLE
Adds html-attribute-indent option

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -354,6 +354,10 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   jsxBracketSameLine: boolean;
   /**
+   *
+   */
+  htmlAttributeIndent: boolean;
+  /**
    * Format only a segment of a file.
    * @default 0
    */

--- a/src/language-html/options.js
+++ b/src/language-html/options.js
@@ -5,6 +5,11 @@ const CATEGORY_HTML = "HTML";
 // format based on https://github.com/prettier/prettier/blob/main/src/main/core-options.evaluate.js
 const options = {
   bracketSameLine: commonOptions.bracketSameLine,
+  htmlAttributeIndent: {
+    category: CATEGORY_HTML,
+    type: "int",
+    default: 0,
+  },
   htmlWhitespaceSensitivity: {
     category: CATEGORY_HTML,
     type: "choice",

--- a/src/language-html/print/tag.js
+++ b/src/language-html/print/tag.js
@@ -5,6 +5,7 @@
 import assert from "node:assert";
 
 import {
+  align,
   hardline,
   indent,
   join,
@@ -265,7 +266,12 @@ function printAttributes(path, options, print) {
 
   /** @type {Doc[]} */
   const parts = [
-    indent([
+    options.htmlAttributeIndent ? align(options.htmlAttributeIndent ,[
+      indent([
+        forceNotToBreakAttrContent ? " " : line,
+        join(attributeLine, printedAttributes),
+      ]),
+    ]) : indent([
       forceNotToBreakAttrContent ? " " : line,
       join(attributeLine, printedAttributes),
     ]),


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
